### PR TITLE
Updating PR review working agreements

### DIFF
--- a/WORKING-AGREEMENTS.md
+++ b/WORKING-AGREEMENTS.md
@@ -19,7 +19,7 @@ Since Waffle is continuously deployed via [Codeship](https://codeship.com) when 
 ### All PRs should be code reviewed and functionally reviewed before merging
 Ideally PRs should also be deployed to our staging environment, if possible.
 
-Wait until someone gives you a :+1: before merging.
+Wait until someone other than the individual or pair doing the work approves the PR. When changing code that a specific person or group of people "own" or have are most invested in, specifically request reviews from that person or group.
 
 PR's should contain [comprehensible commit
 messages](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)

--- a/WORKING-AGREEMENTS.md
+++ b/WORKING-AGREEMENTS.md
@@ -19,7 +19,7 @@ Since Waffle is continuously deployed via [Codeship](https://codeship.com) when 
 ### All PRs should be code reviewed and functionally reviewed before merging
 Ideally PRs should also be deployed to our staging environment, if possible.
 
-Wait until someone other than the individual or pair doing the work approves the PR. When changing code that a specific person or group of people "own" or have are most invested in, specifically request reviews from that person or group.
+Wait until someone other than the individual or pair doing the work approves the PR. When changing code that a specific person either owns or has a high level of investment in, specifically request reviews from that person.
 
 PR's should contain [comprehensible commit
 messages](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)


### PR DESCRIPTION
GitHub just released a new PR review process. It formalizes the process of someone approving a pull request. This is a much more wholistic method of review than just doing :+1:'s.